### PR TITLE
categoriesテーブルとunitsテーブルを作成し初期データを投入するようにしました。

### DIFF
--- a/flash_english_backend/database/categories_seed.php
+++ b/flash_english_backend/database/categories_seed.php
@@ -1,0 +1,53 @@
+<?php
+function runCategoriesSeed(PDO $pdo)
+{
+	$json = json_decode(
+		file_get_contents(__DIR__ . '/seeds/categories.json'),
+		true,
+		512,
+		JSON_THROW_ON_ERROR
+	);
+	echo "== Run Categories Seed count=" . count($json) . " ==\n";
+	$pdo->beginTransaction();
+	try {
+		foreach ($json as $index => $category) {
+			if (
+				!isset($category['category_id']) ||
+				$category['category_id'] === null ||
+				!isset($category['category_no']) ||
+				!isset($category['category_name']) ||
+				!isset($category['category_description'])
+			) {
+				echo "Broken record at index {$index}: missing required fields\n";
+				var_dump($category);
+				$pdo->rollBack();
+				exit;
+			}
+			$stmt = $pdo->prepare("
+        INSERT INTO categories (
+            category_id,
+            category_no,
+            category_name,
+            category_description
+        )
+        VALUES (
+            :category_id,
+            :category_no,
+            :category_name,
+            :category_description
+        )
+    ");
+
+			$stmt->execute([
+				':category_id' => $category['category_id'],
+				':category_no' => $category['category_no'],
+				':category_name' => $category['category_name'],
+				':category_description' => $category['category_description'],
+			]);
+		}
+		$pdo->commit();
+	} catch (\Exception $e) {
+		$pdo->rollBack();
+		throw $e;
+	}
+}

--- a/flash_english_backend/database/categories_seed.php
+++ b/flash_english_backend/database/categories_seed.php
@@ -10,6 +10,20 @@ function runCategoriesSeed(PDO $pdo)
 	echo "== Run Categories Seed count=" . count($json) . " ==\n";
 	$pdo->beginTransaction();
 	try {
+		$stmt = $pdo->prepare("
+      INSERT INTO categories (
+        category_id,
+        category_no,
+        category_name,
+        category_description
+      )
+      VALUES (
+        :category_id,
+        :category_no,
+        :category_name,
+        :category_description
+      )
+    ");
 		foreach ($json as $index => $category) {
 			if (
 				!isset($category['category_id']) ||
@@ -23,20 +37,6 @@ function runCategoriesSeed(PDO $pdo)
 				$pdo->rollBack();
 				exit;
 			}
-			$stmt = $pdo->prepare("
-        INSERT INTO categories (
-            category_id,
-            category_no,
-            category_name,
-            category_description
-        )
-        VALUES (
-            :category_id,
-            :category_no,
-            :category_name,
-            :category_description
-        )
-    ");
 
 			$stmt->execute([
 				':category_id' => $category['category_id'],

--- a/flash_english_backend/database/migration.php
+++ b/flash_english_backend/database/migration.php
@@ -3,6 +3,8 @@ require_once __DIR__ . '/../bootstrap/app.php';
 require_once BASE_PATH . '/bootstrap/logger.php';
 require_once BASE_PATH . '/vendor/autoload.php';
 require_once __DIR__ . '/questions_seed.php';
+require_once __DIR__ . '/categories_seed.php';
+require_once __DIR__ . '/units_seed.php';
 
 // ==============================
 // 1. PDO接続
@@ -57,4 +59,6 @@ runSqlFiles($pdo, __DIR__ . '/migrations');
 echo "== Run Seeds ==\n";
 runSqlFiles($pdo, __DIR__ . '/seeds');
 runQuestionsSeed($pdo);
+runCategoriesSeed($pdo);
+runUnitsSeed($pdo);
 echo "✅ Done!\n";

--- a/flash_english_backend/database/migrations/006_categories.sql
+++ b/flash_english_backend/database/migrations/006_categories.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS categories;
+
+CREATE TABLE categories (
+    category_id INTEGER PRIMARY KEY,
+    category_no INTEGER NOT NULL,
+    category_name TEXT NOT NULL,
+    category_description TEXT NOT NULL,
+    UNIQUE(category_no),
+
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);

--- a/flash_english_backend/database/migrations/007_units.sql
+++ b/flash_english_backend/database/migrations/007_units.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS units;
+
+CREATE TABLE units (
+    unit_id INTEGER PRIMARY KEY,
+    category_no INTEGER NOT NULL,
+    unit_no INTEGER NOT NULL,
+    unit_name TEXT NOT NULL,
+    unit_description TEXT NOT NULL,
+    UNIQUE(category_no, unit_no),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);

--- a/flash_english_backend/database/migrations/007_units.sql
+++ b/flash_english_backend/database/migrations/007_units.sql
@@ -7,6 +7,11 @@ CREATE TABLE units (
     unit_name TEXT NOT NULL,
     unit_description TEXT NOT NULL,
     UNIQUE(category_no, unit_no),
+    CONSTRAINT fk_units_category_no
+      FOREIGN KEY (category_no)
+      REFERENCES categories(category_no)
+      ON DELETE RESTRICT
+      ON UPDATE CASCADE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );

--- a/flash_english_backend/database/questions_seed.php
+++ b/flash_english_backend/database/questions_seed.php
@@ -10,6 +10,28 @@ function runQuestionsSeed(PDO $pdo)
 	echo "== Run Questions Seed count=" . count($json) . " ==\n";
 	$pdo->beginTransaction();
 	try {
+		$stmt = $pdo->prepare("
+      INSERT INTO questions (
+        question_id,
+        category_no,
+        unit_no,
+        question_no,
+        japanese,
+        english,
+        japanese_audio_path,
+        english_audio_path
+      )
+      VALUES (
+        :question_id,
+        :category_no,
+        :unit_no,
+        :question_no,
+        :japanese,
+        :english,
+        :japanese_audio_path,
+        :english_audio_path
+      )
+    ");
 		foreach ($json as $index => $question) {
 			if (
 				!isset($question['question_id']) ||
@@ -25,29 +47,6 @@ function runQuestionsSeed(PDO $pdo)
 				$pdo->rollBack();
 				exit;
 			}
-			$stmt = $pdo->prepare("
-        INSERT INTO questions (
-            question_id,
-            category_no,
-            unit_no,
-            question_no,
-            japanese,
-            english,
-            japanese_audio_path,
-            english_audio_path
-        )
-        VALUES (
-            :question_id,
-            :category_no,
-            :unit_no,
-            :question_no,
-            :japanese,
-            :english,
-            :japanese_audio_path,
-            :english_audio_path
-        )
-    ");
-
 			$stmt->execute([
 				':question_id' => $question['question_id'],
 				':category_no' => $question['category_no'],

--- a/flash_english_backend/database/seeds/categories.json
+++ b/flash_english_backend/database/seeds/categories.json
@@ -1,0 +1,20 @@
+[
+    {
+        "category_id": 1,
+        "category_no": 1,
+        "category_name": "Part1 中学1年レベル",
+        "category_description": "レベル1(中学1年生)"
+    },
+    {
+        "category_id": 2,
+        "category_no": 2,
+        "category_name": "Part2 中学2年レベル",
+        "category_description": "レベル2(中学2年生)"
+    },
+    {
+        "category_id": 3,
+        "category_no": 3,
+        "category_name": "Part3 中学3年レベル",
+        "category_description": "レベル3(中学3年生)"
+    }
+]

--- a/flash_english_backend/database/seeds/units.json
+++ b/flash_english_backend/database/seeds/units.json
@@ -1,0 +1,555 @@
+[
+    {
+        "unit_id": 1,
+        "category_no": 1,
+        "unit_no": 1,
+        "unit_name": "ユニット01",
+        "unit_description": "this/that"
+    },
+    {
+        "unit_id": 2,
+        "category_no": 1,
+        "unit_no": 2,
+        "unit_name": "ユニット02",
+        "unit_description": "these/those"
+    },
+    {
+        "unit_id": 3,
+        "category_no": 1,
+        "unit_no": 3,
+        "unit_name": "ユニット03",
+        "unit_description": "What is (are) 〜 ?"
+    },
+    {
+        "unit_id": 4,
+        "category_no": 1,
+        "unit_no": 4,
+        "unit_name": "ユニット04",
+        "unit_description": "人称代名詞の主格"
+    },
+    {
+        "unit_id": 5,
+        "category_no": 1,
+        "unit_no": 5,
+        "unit_name": "ユニット05",
+        "unit_description": "人称代名詞の所有格"
+    },
+    {
+        "unit_id": 6,
+        "category_no": 1,
+        "unit_no": 6,
+        "unit_name": "ユニット06",
+        "unit_description": "Who is (are) 〜 ?"
+    },
+    {
+        "unit_id": 7,
+        "category_no": 1,
+        "unit_no": 7,
+        "unit_name": "ユニット07",
+        "unit_description": "一般動詞"
+    },
+    {
+        "unit_id": 8,
+        "category_no": 1,
+        "unit_no": 8,
+        "unit_name": "ユニット08",
+        "unit_description": "how many (much) 〜"
+    },
+    {
+        "unit_id": 9,
+        "category_no": 1,
+        "unit_no": 9,
+        "unit_name": "ユニット09",
+        "unit_description": "人称代名詞の目的格"
+    },
+    {
+        "unit_id": 10,
+        "category_no": 1,
+        "unit_no": 10,
+        "unit_name": "ユニット10",
+        "unit_description": "人称代名詞の独立所有格"
+    },
+    {
+        "unit_id": 11,
+        "category_no": 1,
+        "unit_no": 11,
+        "unit_name": "ユニット11",
+        "unit_description": "命令文/Let's 〜"
+    },
+    {
+        "unit_id": 12,
+        "category_no": 1,
+        "unit_no": 12,
+        "unit_name": "ユニット12",
+        "unit_description": "whose"
+    },
+    {
+        "unit_id": 13,
+        "category_no": 1,
+        "unit_no": 13,
+        "unit_name": "ユニット13",
+        "unit_description": "where"
+    },
+    {
+        "unit_id": 14,
+        "category_no": 1,
+        "unit_no": 14,
+        "unit_name": "ユニット14",
+        "unit_description": "when"
+    },
+    {
+        "unit_id": 15,
+        "category_no": 1,
+        "unit_no": 15,
+        "unit_name": "ユニット15",
+        "unit_description": "which"
+    },
+    {
+        "unit_id": 16,
+        "category_no": 1,
+        "unit_no": 16,
+        "unit_name": "ユニット16",
+        "unit_description": "it"
+    },
+    {
+        "unit_id": 17,
+        "category_no": 1,
+        "unit_no": 17,
+        "unit_name": "ユニット17",
+        "unit_description": "What time 〜 ?"
+    },
+    {
+        "unit_id": 18,
+        "category_no": 1,
+        "unit_no": 18,
+        "unit_name": "ユニット18",
+        "unit_description": "how"
+    },
+    {
+        "unit_id": 19,
+        "category_no": 1,
+        "unit_no": 19,
+        "unit_name": "ユニット19",
+        "unit_description": "How old (tall) 〜 ?"
+    },
+    {
+        "unit_id": 20,
+        "category_no": 1,
+        "unit_no": 20,
+        "unit_name": "ユニット20",
+        "unit_description": "疑問詞主語のwho"
+    },
+    {
+        "unit_id": 21,
+        "category_no": 1,
+        "unit_no": 21,
+        "unit_name": "ユニット21",
+        "unit_description": "can"
+    },
+    {
+        "unit_id": 22,
+        "category_no": 1,
+        "unit_no": 22,
+        "unit_name": "ユニット22",
+        "unit_description": "現在進行形"
+    },
+    {
+        "unit_id": 23,
+        "category_no": 1,
+        "unit_no": 23,
+        "unit_name": "ユニット23",
+        "unit_description": "There is (are) 〜"
+    },
+    {
+        "unit_id": 24,
+        "category_no": 2,
+        "unit_no": 1,
+        "unit_name": "ユニット01",
+        "unit_description": "過去形"
+    },
+    {
+        "unit_id": 25,
+        "category_no": 2,
+        "unit_no": 2,
+        "unit_name": "ユニット02",
+        "unit_description": "過去進行形"
+    },
+    {
+        "unit_id": 26,
+        "category_no": 2,
+        "unit_no": 3,
+        "unit_name": "ユニット03",
+        "unit_description": "when節"
+    },
+    {
+        "unit_id": 27,
+        "category_no": 2,
+        "unit_no": 4,
+        "unit_name": "ユニット04",
+        "unit_description": "一般動詞のSVC"
+    },
+    {
+        "unit_id": 28,
+        "category_no": 2,
+        "unit_no": 5,
+        "unit_name": "ユニット05",
+        "unit_description": "SVO+to (for)"
+    },
+    {
+        "unit_id": 29,
+        "category_no": 2,
+        "unit_no": 6,
+        "unit_name": "ユニット06",
+        "unit_description": "SVOO"
+    },
+    {
+        "unit_id": 30,
+        "category_no": 2,
+        "unit_no": 7,
+        "unit_name": "ユニット07",
+        "unit_description": "will (単純未来)"
+    },
+    {
+        "unit_id": 31,
+        "category_no": 2,
+        "unit_no": 8,
+        "unit_name": "ユニット08",
+        "unit_description": "will (意志未来)"
+    },
+    {
+        "unit_id": 32,
+        "category_no": 2,
+        "unit_no": 9,
+        "unit_name": "ユニット09",
+        "unit_description": "will (依頼) / shall (申し出・誘い)"
+    },
+    {
+        "unit_id": 33,
+        "category_no": 2,
+        "unit_no": 10,
+        "unit_name": "ユニット10",
+        "unit_description": "be going to"
+    },
+    {
+        "unit_id": 34,
+        "category_no": 2,
+        "unit_no": 11,
+        "unit_name": "ユニット11",
+        "unit_description": "must / may"
+    },
+    {
+        "unit_id": 35,
+        "category_no": 2,
+        "unit_no": 12,
+        "unit_name": "ユニット12",
+        "unit_description": "have to"
+    },
+    {
+        "unit_id": 36,
+        "category_no": 2,
+        "unit_no": 13,
+        "unit_name": "ユニット13",
+        "unit_description": "be able to"
+    },
+    {
+        "unit_id": 37,
+        "category_no": 2,
+        "unit_no": 14,
+        "unit_name": "ユニット14",
+        "unit_description": "感嘆文"
+    },
+    {
+        "unit_id": 38,
+        "category_no": 2,
+        "unit_no": 15,
+        "unit_name": "ユニット15",
+        "unit_description": "不定詞ー名詞的用法"
+    },
+    {
+        "unit_id": 39,
+        "category_no": 2,
+        "unit_no": 16,
+        "unit_name": "ユニット16",
+        "unit_description": "不定詞ー副詞的用法（目的）"
+    },
+    {
+        "unit_id": 40,
+        "category_no": 2,
+        "unit_no": 17,
+        "unit_name": "ユニット17",
+        "unit_description": "不定詞ー副詞的用法（感情の原因）"
+    },
+    {
+        "unit_id": 41,
+        "category_no": 2,
+        "unit_no": 18,
+        "unit_name": "ユニット18",
+        "unit_description": "不定詞ー形容詞的用法"
+    },
+    {
+        "unit_id": 42,
+        "category_no": 2,
+        "unit_no": 19,
+        "unit_name": "ユニット19",
+        "unit_description": "動名詞"
+    },
+    {
+        "unit_id": 43,
+        "category_no": 2,
+        "unit_no": 20,
+        "unit_name": "ユニット20",
+        "unit_description": "原級比較"
+    },
+    {
+        "unit_id": 44,
+        "category_no": 2,
+        "unit_no": 21,
+        "unit_name": "ユニット21",
+        "unit_description": "比較級ーer形"
+    },
+    {
+        "unit_id": 45,
+        "category_no": 2,
+        "unit_no": 22,
+        "unit_name": "ユニット22",
+        "unit_description": "最上級ーest形"
+    },
+    {
+        "unit_id": 46,
+        "category_no": 2,
+        "unit_no": 23,
+        "unit_name": "ユニット23",
+        "unit_description": "比較級ーmore"
+    },
+    {
+        "unit_id": 47,
+        "category_no": 2,
+        "unit_no": 24,
+        "unit_name": "ユニット24",
+        "unit_description": "最上級ーmost"
+    },
+    {
+        "unit_id": 48,
+        "category_no": 2,
+        "unit_no": 25,
+        "unit_name": "ユニット25",
+        "unit_description": "比較級ー副詞"
+    },
+    {
+        "unit_id": 49,
+        "category_no": 2,
+        "unit_no": 26,
+        "unit_name": "ユニット26",
+        "unit_description": "最上級ー副詞"
+    },
+    {
+        "unit_id": 50,
+        "category_no": 2,
+        "unit_no": 27,
+        "unit_name": "ユニット27",
+        "unit_description": "比較級、最上級を使った疑問詞の文"
+    },
+    {
+        "unit_id": 51,
+        "category_no": 2,
+        "unit_no": 28,
+        "unit_name": "ユニット28",
+        "unit_description": "現在完了ー継続"
+    },
+    {
+        "unit_id": 52,
+        "category_no": 2,
+        "unit_no": 29,
+        "unit_name": "ユニット29",
+        "unit_description": "現在完了ー完了"
+    },
+    {
+        "unit_id": 53,
+        "category_no": 2,
+        "unit_no": 30,
+        "unit_name": "ユニット30",
+        "unit_description": "現在完了ー経験"
+    },
+    {
+        "unit_id": 54,
+        "category_no": 2,
+        "unit_no": 31,
+        "unit_name": "ユニット31",
+        "unit_description": "現在完了進行形"
+    },
+    {
+        "unit_id": 55,
+        "category_no": 2,
+        "unit_no": 32,
+        "unit_name": "ユニット32",
+        "unit_description": "that節"
+    },
+    {
+        "unit_id": 56,
+        "category_no": 2,
+        "unit_no": 33,
+        "unit_name": "ユニット33",
+        "unit_description": "受身−１"
+    },
+    {
+        "unit_id": 57,
+        "category_no": 2,
+        "unit_no": 34,
+        "unit_name": "ユニット34",
+        "unit_description": "受身−２"
+    },
+    {
+        "unit_id": 58,
+        "category_no": 3,
+        "unit_no": 1,
+        "unit_name": "ユニット01",
+        "unit_description": "従属節を導く接続詞−１"
+    },
+    {
+        "unit_id": 59,
+        "category_no": 3,
+        "unit_no": 2,
+        "unit_name": "ユニット02",
+        "unit_description": "従属節を導く接続詞−２"
+    },
+    {
+        "unit_id": 60,
+        "category_no": 3,
+        "unit_no": 3,
+        "unit_name": "ユニット03",
+        "unit_description": "関節疑問文"
+    },
+    {
+        "unit_id": 61,
+        "category_no": 3,
+        "unit_no": 4,
+        "unit_name": "ユニット04",
+        "unit_description": "疑問詞+to 不定詞"
+    },
+    {
+        "unit_id": 62,
+        "category_no": 3,
+        "unit_no": 5,
+        "unit_name": "ユニット05",
+        "unit_description": "形式主語のit"
+    },
+    {
+        "unit_id": 63,
+        "category_no": 3,
+        "unit_no": 6,
+        "unit_name": "ユニット06",
+        "unit_description": "SVO+to 不定詞"
+    },
+    {
+        "unit_id": 64,
+        "category_no": 3,
+        "unit_no": 7,
+        "unit_name": "ユニット07",
+        "unit_description": "SVOC"
+    },
+    {
+        "unit_id": 65,
+        "category_no": 3,
+        "unit_no": 8,
+        "unit_name": "ユニット08",
+        "unit_description": "現在分詞修飾"
+    },
+    {
+        "unit_id": 66,
+        "category_no": 3,
+        "unit_no": 9,
+        "unit_name": "ユニット09",
+        "unit_description": "過去分詞修飾"
+    },
+    {
+        "unit_id": 67,
+        "category_no": 3,
+        "unit_no": 10,
+        "unit_name": "ユニット10",
+        "unit_description": "関係代名詞・主格（人）"
+    },
+    {
+        "unit_id": 68,
+        "category_no": 3,
+        "unit_no": 11,
+        "unit_name": "ユニット11",
+        "unit_description": "関係代名詞・主格（人以外）"
+    },
+    {
+        "unit_id": 69,
+        "category_no": 3,
+        "unit_no": 12,
+        "unit_name": "ユニット12",
+        "unit_description": "関係代名詞・所有格whoseとof which"
+    },
+    {
+        "unit_id": 70,
+        "category_no": 3,
+        "unit_no": 13,
+        "unit_name": "ユニット13",
+        "unit_description": "関係代名詞・目的格（人）"
+    },
+    {
+        "unit_id": 71,
+        "category_no": 3,
+        "unit_no": 14,
+        "unit_name": "ユニット14",
+        "unit_description": "関係代名詞・目的格（人以外）"
+    },
+    {
+        "unit_id": 72,
+        "category_no": 3,
+        "unit_no": 15,
+        "unit_name": "ユニット15",
+        "unit_description": "先行詞を含む関係代名詞what"
+    },
+    {
+        "unit_id": 73,
+        "category_no": 3,
+        "unit_no": 16,
+        "unit_name": "ユニット16",
+        "unit_description": "too 〜 to …"
+    },
+    {
+        "unit_id": 74,
+        "category_no": 3,
+        "unit_no": 17,
+        "unit_name": "ユニット17",
+        "unit_description": "enough 〜 to …"
+    },
+    {
+        "unit_id": 75,
+        "category_no": 3,
+        "unit_no": 18,
+        "unit_name": "ユニット18",
+        "unit_description": "so 〜 that …"
+    },
+    {
+        "unit_id": 76,
+        "category_no": 3,
+        "unit_no": 19,
+        "unit_name": "ユニット19",
+        "unit_description": "原型不定詞・知覚"
+    },
+    {
+        "unit_id": 77,
+        "category_no": 3,
+        "unit_no": 20,
+        "unit_name": "ユニット20",
+        "unit_description": "原型不定詞・使役"
+    },
+    {
+        "unit_id": 78,
+        "category_no": 3,
+        "unit_no": 21,
+        "unit_name": "ユニット21",
+        "unit_description": "関係副詞・where"
+    },
+    {
+        "unit_id": 79,
+        "category_no": 3,
+        "unit_no": 22,
+        "unit_name": "ユニット22",
+        "unit_description": "関係副詞・when"
+    }
+]

--- a/flash_english_backend/database/units_seed.php
+++ b/flash_english_backend/database/units_seed.php
@@ -10,6 +10,22 @@ function runUnitsSeed(PDO $pdo)
 	echo "== Run Units Seed count=" . count($json) . " ==\n";
 	$pdo->beginTransaction();
 	try {
+		$stmt = $pdo->prepare("
+      INSERT INTO units (
+        unit_id,
+        category_no,
+		    unit_no,
+        unit_name,
+        unit_description
+      )
+      VALUES (
+        :unit_id,
+        :category_no,
+        :unit_no,
+        :unit_name,
+        :unit_description
+  	  )
+    ");
 		foreach ($json as $index => $unit) {
 			if (
 				!isset($unit['unit_id']) ||
@@ -24,22 +40,7 @@ function runUnitsSeed(PDO $pdo)
 				$pdo->rollBack();
 				exit;
 			}
-			$stmt = $pdo->prepare("
-        INSERT INTO units (
-            unit_id,
-            category_no,
-            unit_no,
-            unit_name,
-            unit_description
-        )
-        VALUES (
-            :unit_id,
-            :category_no,
-            :unit_no,
-            :unit_name,
-            :unit_description
-        )
-    ");
+
 
 			$stmt->execute([
 				':unit_id' => $unit['unit_id'],

--- a/flash_english_backend/database/units_seed.php
+++ b/flash_english_backend/database/units_seed.php
@@ -35,10 +35,9 @@ function runUnitsSeed(PDO $pdo)
 				!isset($unit['unit_name']) ||
 				!isset($unit['unit_description'])
 			) {
-				echo "Broken record at index {$index}: missing required fields\n";
-				var_dump($unit);
-				$pdo->rollBack();
-				exit;
+				throw new RuntimeException(
+					"Broken unit record at index {$index}: missing required fields"
+				);
 			}
 
 

--- a/flash_english_backend/database/units_seed.php
+++ b/flash_english_backend/database/units_seed.php
@@ -1,0 +1,57 @@
+<?php
+function runUnitsSeed(PDO $pdo)
+{
+	$json = json_decode(
+		file_get_contents(__DIR__ . '/seeds/units.json'),
+		true,
+		512,
+		JSON_THROW_ON_ERROR
+	);
+	echo "== Run Units Seed count=" . count($json) . " ==\n";
+	$pdo->beginTransaction();
+	try {
+		foreach ($json as $index => $unit) {
+			if (
+				!isset($unit['unit_id']) ||
+				$unit['unit_id'] === null ||
+				!isset($unit['category_no']) ||
+				!isset($unit['unit_no']) ||
+				!isset($unit['unit_name']) ||
+				!isset($unit['unit_description'])
+			) {
+				echo "Broken record at index {$index}: missing required fields\n";
+				var_dump($unit);
+				$pdo->rollBack();
+				exit;
+			}
+			$stmt = $pdo->prepare("
+        INSERT INTO units (
+            unit_id,
+            category_no,
+            unit_no,
+            unit_name,
+            unit_description
+        )
+        VALUES (
+            :unit_id,
+            :category_no,
+            :unit_no,
+            :unit_name,
+            :unit_description
+        )
+    ");
+
+			$stmt->execute([
+				':unit_id' => $unit['unit_id'],
+				':category_no' => $unit['category_no'],
+				':unit_no' => $unit['unit_no'],
+				':unit_name' => $unit['unit_name'],
+				':unit_description' => $unit['unit_description'],
+			]);
+		}
+		$pdo->commit();
+	} catch (\Exception $e) {
+		$pdo->rollBack();
+		throw $e;
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 学習コンテンツを「カテゴリ」と「ユニット」で管理するデータベース構造を追加しました。
  * 初期データとして3つのカテゴリ（中学1〜3年）と79個のユニットを登録しました。

* **改善**
  * カテゴリ／ユニット間の整合性を保ちながら、移行時のシード投入を行えるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->